### PR TITLE
Autofix: [BUG 🐛] Mirroring makes detection of yaw faulty

### DIFF
--- a/ios/VisionCameraFaceDetector.swift
+++ b/ios/VisionCameraFaceDetector.swift
@@ -305,7 +305,7 @@ public class VisionCameraFaceDetector: FrameProcessorPlugin {
 
         map["rollAngle"] = face.headEulerAngleZ
         map["pitchAngle"] = face.headEulerAngleX
-        map["yawAngle"] = face.headEulerAngleY
+        map["yawAngle"] = -face.headEulerAngleY  // Invert yawAngle for iOS
         map["bounds"] = processBoundingBox(
           from: face,
           sourceWidth: width,


### PR DESCRIPTION
I have identified the issue with the yawAngle being mirrored on iOS. The problem lies in the `VisionCameraFaceDetector.swift` file. To solve this, I've made a modification to the `callback` function to invert the yawAngle for iOS devices. This should ensure consistent behavior across both iOS and Android platforms. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission