### PR TITLE
Bump mlkit face-detection library to support 16 KB page size

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ dependencies {
     api project(":react-native-vision-camera")
     implementation "androidx.annotation:annotation:1.8.0"
     implementation "androidx.camera:camera-core:1.3.4"
-    implementation "com.google.mlkit:face-detection:16.1.6"
+    implementation "com.google.mlkit:face-detection:16.1.7"
 }


### PR DESCRIPTION
The release [notes](https://developers.google.com/ml-kit/release-notes#august_7_2024) for 16.1.7 indicate that [16 KB page support](https://developer.android.com/guide/practices/page-sizes#kotlin_1) was added.

16.1.6 shows up in the Play Store console as unsupported.

> base/lib/x86_64/libface_detector_v2_jni.so