### PR TITLE
fix: unwrap generated InputImage variant in ImageFaceDetector

### DIFF
--- a/android/src/main/java/com/margelo/nitro/camera/facedetector/HybridImageFaceDetector.kt
+++ b/android/src/main/java/com/margelo/nitro/camera/facedetector/HybridImageFaceDetector.kt
@@ -22,14 +22,11 @@ class HybridImageFaceDetector(
   )
 
   private fun resolveInputImage(
-    input: Any?
+    input: InputImage
   ): String {
     return when (input) {
-      is String -> input
-      is Map<*, *> -> {
-        val uri = input["uri"] as? String
-        uri ?: throw IllegalArgumentException("Invalid image object: missing 'uri'")
-      }
+      is InputImage.First -> input.value
+      is InputImage.Third -> input.value.uri
       else -> throw IllegalArgumentException("Invalid image type. Expected string or { uri }")
     }
   }

--- a/ios/HybridImageFaceDetector.swift
+++ b/ios/HybridImageFaceDetector.swift
@@ -52,15 +52,15 @@ class HybridImageFaceDetector: HybridImageFaceDetectorSpec {
   }
 
   private func resolveInputImage(
-    _ input: Any
+    _ input: InputImage
   ) throws -> String {
-    if let uri = input as? String {
+    switch input {
+    case .first(let uri):
       return uri
-    }
-
-    if let object = input as? [String: Any],
-      let uri = object["uri"] as? String {
-      return uri
+    case .third(let object):
+      return object.uri
+    case .second:
+      break
     }
 
     throw NSError(


### PR DESCRIPTION
Fixes #241.

`ImageFaceDetector.detectFaces` currently throws `Invalid image type. Expected string or { uri }` for **every** input, on **both** platforms — the still-image API can't succeed at all on `main` (cddea4ed) or on any published 2.x.

### Cause

`InputImage` is declared as a TS union:

```ts
export type InputImage = string | number | ImageUri
```

Nitrogen marshals that into a generated wrapper type — a Swift enum and a Kotlin sealed class:

```swift
public indirect enum InputImage {
  case first(String)
  case second(Double)
  case third(ImageUri)
}
```

```kotlin
sealed class InputImage {
  data class First(val value: String): InputImage()
  data class Second(val value: Double): InputImage()
  data class Third(val value: ImageUri): InputImage()
}
```

But `resolveInputImage` declares its parameter as `Any` / `Any?` and tests the raw value (`input as? String`, `input as? [String: Any]`, `is String`, `is Map<*, *>`). Those tests are against the *unwrapped* shapes, and what arrives is the wrapper, so none of them can ever match and the fallthrough error is thrown unconditionally.

### Fix

Type the parameter as `InputImage` and unwrap the generated cases:

- `.first` / `First` → the `String` uri
- `.third` / `Third` → `ImageUri.uri`
- `.second` / else → falls through to the existing error, unchanged (there's no image to resolve from a `Double`; the arm stays declared-but-unsupported exactly as before)

Typing the parameter as `InputImage` rather than `Any` is the part that matters beyond this one fix: it makes the compiler enforce exhaustive handling, so a future arm added to the union can't silently regress into a runtime throw again.

No public API, TS types, or generated-code changes — behavior for callers goes from "always throws" to "resolves string and `{ uri }` inputs", which is what the type has always advertised.

### Testing

- iOS: verified against a real still-photo pipeline (front-camera capture → `file://` uri → `createImageFaceDetector({ performanceMode: 'accurate', runLandmarks: true }).detectFaces(uri)`), which returned faces with landmarks instead of throwing. Has been running as a patch-package patch against `2.0.1` in a production app.
- Android: fix is the direct analogue of the iOS one and matches the generated sealed-class shape; I don't have an Android device in this project's loop, so I'd appreciate a second pair of eyes there. The reporter in #241 was on Android and can likely confirm.
